### PR TITLE
add reports endpoints (volunteers, events, assignments) with CSV/PDF export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "express": "^5.1.0",
         "joi": "^17.12.2",
         "nodemailer": "^7.0.5",
+        "pdfkit": "^0.17.1",
         "pg": "^8.11.3",
         "react": "^19.1.0",
         "react-datepicker": "^8.4.0",
@@ -3682,6 +3683,14 @@
         "url": "https://github.com/sponsors/gregberge"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -5515,6 +5524,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5634,6 +5662,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browser-process-hrtime": {
@@ -5974,6 +6010,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clsx": {
@@ -6375,6 +6419,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -7052,6 +7101,11 @@
         "asap": "^2.0.0",
         "wrappy": "1"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -8657,6 +8711,22 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/for-each": {
@@ -11429,6 +11499,11 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11700,6 +11775,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/lines-and-columns": {
@@ -12674,6 +12766,11 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -12810,6 +12907,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pdfkit": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.17.1.tgz",
+      "integrity": "sha512-Kkf1I9no14O/uo593DYph5u3QwiMfby7JsBSErN1WqeyTgCBNJE3K4pXBn3TgkdKUIVu+buSl4bYUNC+8Up4xg==",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.4",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.1.0",
+        "png-js": "^1.0.0"
       }
     },
     "node_modules/performance-now": {
@@ -13012,6 +13121,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/png-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
+      "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -15295,6 +15409,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw=="
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -17266,6 +17385,11 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -17633,6 +17757,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
@@ -17640,6 +17773,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/unique-string": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "express": "^5.1.0",
     "joi": "^17.12.2",
     "nodemailer": "^7.0.5",
+    "pdfkit": "^0.17.1",
     "pg": "^8.11.3",
     "react": "^19.1.0",
     "react-datepicker": "^8.4.0",

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const historyRoutes   = require('./src/api/historyRoutes');    // points to your
 const profileRoutes   = require('./src/api/profileRoutes');
 const authRoutes      = require('./src/api/authRoutes');
 const notificationRoutes = require('./src/api/notificationRoutes');
+const reportRoutes      = require('./src/api/reportRoutes');
 
 const app  = express();
 const PORT = process.env.PORT || 5000;  // picks up env PORT if set
@@ -31,6 +32,7 @@ app.use('/api/history',       historyRoutes);
 app.use('/api/profiles',      profileRoutes);
 app.use('/api/auth',          authRoutes);
 app.use('/api/notifications', notificationRoutes);
+app.use('/api/reports',       reportRoutes);
 
 // Health-check
 app.get('/api/test', (req, res) => {

--- a/src/api/reportRoutes.js
+++ b/src/api/reportRoutes.js
@@ -102,6 +102,80 @@ async function buildVolunteerReport({ start, end, userId }) {
   }));
 }
 
+async function buildEventReport({ start, end, eventId }) {
+    const startDate = parseDateOrNull(start);
+    const endDate = parseDateOrNull(end);
+    const filters = [];
+    const params = [];
+    if (eventId) { params.push(eventId); filters.push(`ed.event_id = $${params.length}`); }
+    if (startDate) { params.push(startDate); filters.push(`ed.event_date >= $${params.length}`); }
+    if (endDate) { params.push(endDate); filters.push(`ed.event_date <= $${params.length}`); }
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const rows = await queryRows(
+        `SELECT 
+           ed.event_id,
+           ed.event_name,
+           ed.event_date,
+           ed.location,
+           COUNT(vh.user_id) FILTER (WHERE vh.status IN ('Assigned','Confirmed','Attended')) AS num_volunteers,
+           AVG(NULLIF(vh.performance_rating,0)) AS avg_rating
+         FROM EventDetails ed
+         LEFT JOIN VolunteerHistory vh ON vh.event_id = ed.event_id
+         ${where}
+         GROUP BY ed.event_id, ed.event_name, ed.event_date, ed.location
+         ORDER BY ed.event_date DESC`,
+        params
+      );
+      return rows.map(r => ({
+        event_id: r.event_id,
+        event_name: r.event_name,
+        event_date: r.event_date,
+        location: r.location,
+        num_volunteers: Number(r.num_volunteers || 0),
+        avg_rating: r.avg_rating ? Number(r.avg_rating).toFixed(2) : null,
+      }));
+}
+
+async function buildAssignmentReport({ start, end, eventId }) {
+    const startDate = parseDateOrNull(start);
+    const endDate = parseDateOrNull(end);
+    const filters = [];
+    const params = [];
+    if (eventId) { params.push(eventId); filters.push(`ed.event_id = $${params.length}`); }
+    if (startDate) { params.push(startDate); filters.push(`ed.event_date >= $${params.length}`); }
+    if (endDate) { params.push(endDate); filters.push(`ed.event_date <= $${params.length}`); }
+    const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    const rows = await queryRows(
+        `SELECT 
+           vh.user_id AS volunteer_id,
+           up.full_name AS volunteer_name,
+           uc.email,
+           vh.event_id,
+           ed.event_name,
+           ed.event_date,
+           vh.status,
+           vh.performance_rating,
+           vh.feedback
+         FROM VolunteerHistory vh
+         JOIN UserCredentials uc ON uc.user_id = vh.user_id
+         LEFT JOIN UserProfile up ON up.user_id = vh.user_id
+         JOIN EventDetails ed ON ed.event_id = vh.event_id
+         ${where}
+         ORDER BY ed.event_date DESC, volunteer_name ASC NULLS LAST`,
+        params
+      );
+      return rows.map(r => ({
+        event_id: r.event_id,
+        event_name: r.event_name,
+        event_date: r.event_date,
+        volunteer_id: r.volunteer_id,
+        volunteer_name: r.volunteer_name,
+        email: r.email,
+        status: r.status,
+        performance_rating: r.performance_rating,
+        feedback: r.feedback,
+      }));
+}
 
 router.get('/volunteers', async (req, res) => {
   try {
@@ -117,6 +191,33 @@ router.get('/volunteers', async (req, res) => {
   }
 });
 
+router.get('/events', async (req, res) => {
+    try {
+        const { start, end, eventId } = req.query;
+        const format = normalizeFormat(req.query.format);
+        const data = await buildEventReport({ start, end, eventId });
+        if (format === 'csv') return sendCsv(res, data, 'events.csv');
+        if (format === 'pdf') return sendPdf(res, data, 'events.pdf', 'Events Report');
+        return res.json({ data });
+    } catch (err) {
+        console.error('Event report error:', err);
+        res.status(500).json({ error: 'Failed to generate event report' });
+    }
+});
+
+router.get('/assignments', async (req, res) => {
+    try {
+        const { start, end, eventId } = req.query;
+        const format = normalizeFormat(req.query.format);
+        const data = await buildAssignmentReport({ start, end, eventId });
+        if (format === 'csv') return sendCsv(res, data, 'assignments.csv');
+        if (format === 'pdf') return sendPdf(res, data, 'assignments.pdf', 'Assignments Report');
+        return res.json({ data });
+    } catch (err) {
+        console.error('Assignment report error:', err);
+        res.status(500).json({ error: 'Failed to generate assignment report' });
+    }
+});
 
 module.exports = router;
 

--- a/src/api/reportRoutes.js
+++ b/src/api/reportRoutes.js
@@ -1,0 +1,123 @@
+const express = require('express');
+const router  = express.Router();
+const PDFDocument = require('pdfkit');
+const db = require('./db');
+
+
+function normalizeFormat(value) {
+  const fmt = (value || 'json').toLowerCase();
+  return fmt === 'csv' || fmt === 'pdf' ? fmt : 'json';
+}
+
+function parseDateOrNull(value) {
+  if (!value) return null;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+async function queryRows(text, params = []) {
+  const client = await db.connect();
+  try {
+    const result = await client.query(text, params);
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+function sendCsv(res, rows, filename = 'report.csv') {
+  res.setHeader('Content-Type', 'text/csv');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  if (!rows || rows.length === 0) return res.send('');
+  const headers = Object.keys(rows[0]);
+  const escape = (val) => {
+    if (val === null || val === undefined) return '';
+    const s = String(val);
+    if (s.includes(',') || s.includes('"') || s.includes('\n')) return '"' + s.replace(/"/g, '""') + '"';
+    return s;
+  };
+  const lines = [headers.join(',')];
+  for (const row of rows) lines.push(headers.map(h => escape(row[h])).join(','));
+  res.send(lines.join('\n'));
+}
+
+function sendPdf(res, rows, filename = 'report.pdf', title = 'Report') {
+  res.setHeader('Content-Type', 'application/pdf');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  const doc = new PDFDocument({ margin: 40, size: 'LETTER' });
+  doc.info.Title = title;
+  doc.pipe(res);
+  doc.fontSize(18).text(title, { align: 'center' });
+  doc.moveDown();
+  if (!rows || rows.length === 0) {
+    doc.fontSize(12).text('No data.');
+    doc.end();
+    return;
+  }
+  const headers = Object.keys(rows[0]);
+  doc.fontSize(12).text(headers.join(' | '));
+  doc.moveDown(0.5);
+  for (const row of rows) {
+    const line = headers.map(h => (row[h] === null || row[h] === undefined) ? '' : String(row[h])).join(' | ');
+    doc.text(line);
+  }
+  doc.end();
+}
+
+async function buildVolunteerReport({ start, end, userId }) {
+  const startDate = parseDateOrNull(start);
+  const endDate = parseDateOrNull(end);
+  const filters = [];
+  const params = [];
+  if (userId) { params.push(userId); filters.push(`vh.user_id = $${params.length}`); }
+  if (startDate) { params.push(startDate); filters.push(`ed.event_date >= $${params.length}`); }
+  if (endDate) { params.push(endDate); filters.push(`ed.event_date <= $${params.length}`); }
+  const where = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+  const rows = await queryRows(
+    `SELECT 
+       uc.user_id AS volunteer_id,
+       up.full_name AS name,
+       uc.email,
+       COUNT(vh.event_id) FILTER (WHERE vh.status IN ('Attended','Confirmed')) AS events_participated,
+       AVG(NULLIF(vh.performance_rating,0)) AS avg_rating,
+       MIN(ed.event_date) AS first_participation,
+       MAX(ed.event_date) AS last_participation
+     FROM UserCredentials uc
+     LEFT JOIN UserProfile up ON up.user_id = uc.user_id
+     LEFT JOIN VolunteerHistory vh ON vh.user_id = uc.user_id
+     LEFT JOIN EventDetails ed ON ed.event_id = vh.event_id
+     ${where}
+     GROUP BY uc.user_id, up.full_name, uc.email
+     ORDER BY last_participation DESC NULLS LAST`,
+    params
+  );
+  return rows.map(r => ({
+    volunteer_id: r.volunteer_id,
+    name: r.name,
+    email: r.email,
+    events_participated: Number(r.events_participated || 0),
+    avg_rating: r.avg_rating ? Number(r.avg_rating).toFixed(2) : null,
+    first_participation: r.first_participation,
+    last_participation: r.last_participation,
+  }));
+}
+
+
+router.get('/volunteers', async (req, res) => {
+  try {
+    const { start, end, userId } = req.query;
+    const format = normalizeFormat(req.query.format);
+    const data = await buildVolunteerReport({ start, end, userId });
+    if (format === 'csv') return sendCsv(res, data, 'volunteers.csv');
+    if (format === 'pdf') return sendPdf(res, data, 'volunteers.pdf', 'Volunteers Report');
+    return res.json({ data });
+  } catch (err) {
+    console.error('Volunteer report error:', err);
+    res.status(500).json({ error: 'Failed to generate volunteer report' });
+  }
+});
+
+
+module.exports = router;
+
+


### PR DESCRIPTION
### Summary

- Adds **/api/reports** with three GET endpoints:

- **/volunteers** (per-volunteer aggregates; filters:`start`, `end`, `userId`)

- **/events** (per-event aggregates; filters: `start`, `end`, `eventId`)

- **/assignments** (per-assignment detail; filters: `start`, `end`, `eventId`)

Supports format=json|csv|pdf (default json).

Found at **src/api/reportRoutes.js**

Examples: 
```bash 
# Volunteers
curl -s "http://localhost:5000/api/reports/volunteers?start=2024-01-01&end=2024-12-31"
curl -s "http://localhost:5000/api/reports/volunteers?userId=42&format=csv" -OJ
curl -s "http://localhost:5000/api/reports/volunteers?format=pdf" -OJ

# Events
curl -s "http://localhost:5000/api/reports/events?start=2024-01-01&end=2024-06-30"
curl -s "http://localhost:5000/api/reports/events?eventId=101&format=csv" -OJ

# Assignments
curl -s "http://localhost:5000/api/reports/assignments?start=2024-05-01&end=2024-05-31"
curl -s "http://localhost:5000/api/reports/assignments?format=pdf" -OJ```
